### PR TITLE
Fix/i18n dashboard

### DIFF
--- a/src/analytics/presentation/components/builder-dashboard.component.vue
+++ b/src/analytics/presentation/components/builder-dashboard.component.vue
@@ -71,7 +71,7 @@ const deviceTypeChartData = computed(() => {
   
   const colors = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899', '#14B8A6'];
   return {
-    labels: Object.keys(props.dashboard.devicesByType),
+    labels: Object.keys(props.dashboard.devicesByType).map(type => translateDeviceType(type)),
     datasets: [{
       data: Object.values(props.dashboard.devicesByType),
       backgroundColor: colors.slice(0, Object.keys(props.dashboard.devicesByType).length),
@@ -121,6 +121,10 @@ const deviceTypeIcons = {
 };
 
 const getDeviceIcon = (type) => deviceTypeIcons[type] || 'pi-box';
+
+const translateDeviceType = (type) => {
+  return t(`analytics.deviceTypes.${type}`, type);
+};
 </script>
 
 <template>
@@ -227,7 +231,7 @@ const getDeviceIcon = (type) => deviceTypeIcons[type] || 'pi-box';
             <i :class="['pi', getDeviceIcon(type), 'text-2xl']"></i>
           </div>
           <div class="device-type-info">
-            <p class="device-type-name">{{ type }}</p>
+            <p class="device-type-name">{{ translateDeviceType(type) }}</p>
             <p class="device-type-count">{{ count }} {{ $t('analytics.builder.sections.devices') }}</p>
           </div>
         </div>

--- a/src/analytics/presentation/components/project-card.component.vue
+++ b/src/analytics/presentation/components/project-card.component.vue
@@ -1,10 +1,18 @@
 <script setup>
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+
 const props = defineProps({
   project: {
     type: Object,
     required: true
   }
 });
+
+const translateStatus = (status) => {
+  return t(`analytics.projectStatus.${status}`, status);
+};
 
 const statusColors = {
   'OnGoing': 'bg-green-100 text-green-800',
@@ -30,7 +38,7 @@ const getStatusColor = (status) => {
         </p>
       </div>
       <span class="project-status" :class="getStatusColor(project.status)">
-        {{ project.status }}
+        {{ translateStatus(project.status) }}
       </span>
     </div>
     
@@ -41,7 +49,7 @@ const getStatusColor = (status) => {
         </span>
         <div class="stat-details">
           <span class="stat-value-small">{{ project.occupiedUnits }}/{{ project.totalUnits }}</span>
-          <span class="stat-label-small">Units</span>
+          <span class="stat-label-small">{{ $t('analytics.common.units') }}</span>
         </div>
       </div>
       
@@ -51,14 +59,14 @@ const getStatusColor = (status) => {
         </span>
         <div class="stat-details">
           <span class="stat-value-small">{{ project.deviceCount }}</span>
-          <span class="stat-label-small">Devices</span>
+          <span class="stat-label-small">{{ $t('analytics.common.devices') }}</span>
         </div>
       </div>
     </div>
     
     <div class="progress-section">
       <div class="progress-header">
-        <span class="progress-label">Occupancy</span>
+        <span class="progress-label">{{ $t('analytics.common.occupancy') }}</span>
         <span class="progress-value">{{ project.occupancyRate.toFixed(1) }}%</span>
       </div>
       <div class="progress-bar">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -385,6 +385,29 @@
     }
   },
   "analytics": {
+    "deviceTypes": {
+      "Temperature": "Temperature",
+      "Humidity": "Humidity",
+      "Energy": "Energy",
+      "Water": "Water",
+      "Lighting": "Lighting",
+      "Access Control": "Access Control",
+      "HVAC": "HVAC",
+      "Construction": "Construction",
+      "Security": "Security"
+    },
+    "projectStatus": {
+      "OnGoing": "Ongoing",
+      "Active": "Active",
+      "Construction": "Construction",
+      "Planned": "Planned",
+      "Completed": "Completed"
+    },
+    "common": {
+      "occupancy": "Occupancy",
+      "units": "Units",
+      "devices": "Devices"
+    },
     "builder": {
       "title": "Builder Dashboard",
       "subtitle": "Comprehensive overview of your construction projects",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -385,6 +385,29 @@
     }
   },
   "analytics": {
+    "deviceTypes": {
+      "Temperature": "Temperatura",
+      "Humidity": "Humedad",
+      "Energy": "Energía",
+      "Water": "Agua",
+      "Lighting": "Iluminación",
+      "Access Control": "Control de Acceso",
+      "HVAC": "HVAC",
+      "Construction": "Construcción",
+      "Security": "Seguridad"
+    },
+    "projectStatus": {
+      "OnGoing": "En Curso",
+      "Active": "Activo",
+      "Construction": "En Construcción",
+      "Planned": "Planeado",
+      "Completed": "Completado"
+    },
+    "common": {
+      "occupancy": "Ocupación",
+      "units": "Unidades",
+      "devices": "Dispositivos"
+    },
     "builder": {
       "title": "Panel del Constructor",
       "subtitle": "Vista general completa de tus proyectos de construcción",


### PR DESCRIPTION
This pull request adds internationalization (i18n) support for device types, project statuses, and common analytics terms in the analytics dashboard and project card components. It introduces translation helpers and updates UI text to use localized strings, ensuring the interface is properly translated for both English and Spanish users.